### PR TITLE
TC aspect changes and misc. bug fixes

### DIFF
--- a/src/main/java/teamroots/embers/compat/thaumcraft/ThaumcraftIntegration.java
+++ b/src/main/java/teamroots/embers/compat/thaumcraft/ThaumcraftIntegration.java
@@ -8,6 +8,7 @@ import thaumcraft.api.aspects.AspectList;
 
 public class ThaumcraftIntegration {
     public static void init() {
+    	registerAspects();
     }
 
     //Special thanks to Mangoose for writing all of this.
@@ -34,6 +35,8 @@ public class ThaumcraftIntegration {
                 new AspectList().add(Aspect.EARTH, 6).add(Aspect.WATER, 3).add(Aspect.FIRE, 1));
         ThaumcraftApi.registerComplexObjectTag(new ItemStack(RegistryManager.ember_detector),
                 new AspectList().add(Aspect.MECHANISM, 10));
+        ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.dust_ember),
+                new AspectList().add(Aspect.FIRE, 15).add(Aspect.ENERGY, 15).add(Aspect.ENTROPY, 5));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.shard_ember),
                 new AspectList().add(Aspect.FIRE, 3).add(Aspect.ENERGY, 3).add(Aspect.CRYSTAL, 3));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.crystal_ember),
@@ -94,6 +97,8 @@ public class ThaumcraftIntegration {
                 new AspectList().add(Aspect.DARKNESS, 3).add(Aspect.ELDRITCH, 5).add(Aspect.EARTH, 11).add(Aspect.PROTECT, 15).add(Aspect.SOUL, 15).add(Aspect.ALCHEMY, 4));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.intelligent_apparatus),
                 new AspectList().add(Aspect.METAL, 33).add(Aspect.MIND, 10).add(Aspect.EXCHANGE, 15).add(Aspect.ORDER, 4).add(Aspect.DESIRE, 7).add(Aspect.ALCHEMY, 3));
+        ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.dust_metallurgic),
+                new AspectList().add(Aspect.METAL, 15).add(Aspect.ENTROPY, 5).add(Aspect.ALCHEMY, 5));
     }
 
     private static void registerOreAspects() {
@@ -186,5 +191,7 @@ public class ThaumcraftIntegration {
                 new AspectList().add(Aspect.EXCHANGE, 3));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.caminite_lever),
                 new AspectList().add(Aspect.EARTH, 2).add(Aspect.MECHANISM, 3));
+        ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.catalytic_plug),
+                new AspectList().add(Aspect.ENERGY, 50).add(Aspect.METAL, 15).add(Aspect.MOTION, 7).add(Aspect.EXCHANGE, 5).add(Aspect.CRYSTAL, 5).add(Aspect.ALCHEMY, 4));
     }
 }

--- a/src/main/java/teamroots/embers/compat/thaumcraft/ThaumcraftIntegration.java
+++ b/src/main/java/teamroots/embers/compat/thaumcraft/ThaumcraftIntegration.java
@@ -28,11 +28,11 @@ public class ThaumcraftIntegration {
         ThaumcraftApi.registerComplexObjectTag(new ItemStack(RegistryManager.tinker_hammer),
                 new AspectList().add(Aspect.TOOL, 10));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.stamp_bar),
-                new AspectList().add(Aspect.EARTH, 6).add(Aspect.WATER, 3).add(Aspect.FIRE, 1));
+                new AspectList().add(Aspect.EARTH, 6).add(Aspect.WATER, 3).add(Aspect.FIRE, 1).add(Aspect.CRAFT, 5));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.stamp_flat),
-                new AspectList().add(Aspect.EARTH, 12).add(Aspect.WATER, 6).add(Aspect.FIRE, 1));
+                new AspectList().add(Aspect.EARTH, 12).add(Aspect.WATER, 6).add(Aspect.FIRE, 1).add(Aspect.CRAFT, 5));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.stamp_plate),
-                new AspectList().add(Aspect.EARTH, 6).add(Aspect.WATER, 3).add(Aspect.FIRE, 1));
+                new AspectList().add(Aspect.EARTH, 6).add(Aspect.WATER, 3).add(Aspect.FIRE, 1).add(Aspect.CRAFT, 5));
         ThaumcraftApi.registerComplexObjectTag(new ItemStack(RegistryManager.ember_detector),
                 new AspectList().add(Aspect.MECHANISM, 10));
         ThaumcraftApi.registerObjectTag(new ItemStack(RegistryManager.dust_ember),

--- a/src/main/java/teamroots/embers/item/bauble/ItemBaubleBase.java
+++ b/src/main/java/teamroots/embers/item/bauble/ItemBaubleBase.java
@@ -25,6 +25,7 @@ public class ItemBaubleBase extends ItemBase implements IBauble {
 	public ItemBaubleBase(String name, BaubleType type, boolean addToTab) {
 		super(name, addToTab);
 		this.type = type;
+		this.setMaxStackSize(1);
 	}
 	
 	@Override

--- a/src/main/java/teamroots/embers/recipe/RecipeRegistry.java
+++ b/src/main/java/teamroots/embers/recipe/RecipeRegistry.java
@@ -604,7 +604,7 @@ public class RecipeRegistry {
 		event.getRegistry().register(new ShapedOreRecipe(getRL("item_dropper"),new ItemStack(RegistryManager.item_dropper,1),true,new Object[]{
 				" P ",
 				"I I",
-				'P', RegistryManager.pipe,
+				'P', RegistryManager.item_pipe,
 				'I', "ingotIron"}).setRegistryName(getRL("item_dropper")));
 		event.getRegistry().register(new ShapedOreRecipe(getRL("large_tank"),new ItemStack(RegistryManager.large_tank,1),true,new Object[]{
 				"Y Y",

--- a/src/main/java/teamroots/embers/tileentity/TileEntityEmitter.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityEmitter.java
@@ -62,8 +62,8 @@ public class TileEntityEmitter extends TileEntity implements ITileEntityBase, IT
 	}
 	
 	public void updateNeighbors(IBlockAccess world){
-		up = getConnection(world,getPos().up(),EnumFacing.DOWN);
-		down = getConnection(world,getPos().down(),EnumFacing.UP);
+		down = getConnection(world,getPos().down(),EnumFacing.DOWN);
+		up = getConnection(world,getPos().up(),EnumFacing.UP);
 		north = getConnection(world,getPos().north(),EnumFacing.NORTH);
 		south = getConnection(world,getPos().south(),EnumFacing.SOUTH);
 		west = getConnection(world,getPos().west(),EnumFacing.WEST);

--- a/src/main/java/teamroots/embers/tileentity/TileEntityPulser.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityPulser.java
@@ -62,8 +62,8 @@ public class TileEntityPulser extends TileEntity implements ITileEntityBase, ITi
 	}
 	
 	public void updateNeighbors(IBlockAccess world){
-		up = getConnection(world,getPos().up(),EnumFacing.DOWN);
-		down = getConnection(world,getPos().down(),EnumFacing.UP);
+		down = getConnection(world,getPos().down(),EnumFacing.DOWN);
+		up = getConnection(world,getPos().up(),EnumFacing.UP);
 		north = getConnection(world,getPos().north(),EnumFacing.NORTH);
 		south = getConnection(world,getPos().south(),EnumFacing.SOUTH);
 		west = getConnection(world,getPos().west(),EnumFacing.WEST);

--- a/src/main/java/teamroots/embers/tileentity/TileEntityStamper.java
+++ b/src/main/java/teamroots/embers/tileentity/TileEntityStamper.java
@@ -106,11 +106,7 @@ public class TileEntityStamper extends TileEntity implements ITileEntityBase, IT
 		ItemStack heldItem = player.getHeldItem(hand);
 		if (!heldItem.isEmpty()) {
 			if (stamp.getStackInSlot(0).isEmpty()) {
-				ItemStack newStack = new ItemStack(heldItem.getItem(), 1, heldItem.getMetadata());
-				if (heldItem.hasTagCompound()) {
-					newStack.setTagCompound(heldItem.getTagCompound());
-				}
-				player.setHeldItem(hand, this.stamp.insertItem(0, newStack, false));
+				player.setHeldItem(hand, this.stamp.insertItem(0, heldItem.copy(), false));
 				markDirty();
 				return true;
 			}

--- a/src/main/resources/assets/embers/lang/en_US.lang
+++ b/src/main/resources/assets/embers/lang/en_US.lang
@@ -492,7 +492,7 @@ embers.research.metallurgy.ejector.desc=Simple Ember Emitters are useful and all
 
 embers.research.metallurgy.catalytic_plug=Catalytic Plug
 embers.research.metallurgy.catalytic_plug.title=Overdrive Injection
-embers.research.metallurgy.catalytic_plug.desc=Catalytic Plugs are fantastic devices for the impatient. When hooked up to a machine the plug double the speed of the machine, but only if also supplied with Alchemical Slurry from the back, which is consumed in the process. Up to 2 Catalytic Plugs can be attached to a single machine, to quadruple its speed.
+embers.research.metallurgy.catalytic_plug.desc=Catalytic Plugs are fantastic devices for the impatient. When hooked up to a machine the plug doubles the speed of the machine, but only if also supplied with Alchemical Slurry from the back, which is consumed in the process. Up to 2 Catalytic Plugs can be attached to a single machine, to quadruple its speed.
 
 
 


### PR DESCRIPTION
- Added aspects to items and blocks that I had forgotten about before
- Added the 'Fabrico' aspect to the stamp items
- Fixed levers not properly connecting to Ember Emitters and Ember Ejectors on the top and bottom faces
- Fixed a typo in the codex page for the Catalytic Plug
- Fixed the Item Dropper using a Fluid Pipe instead of an Item Pipe in its recipe
- Fixed the Stamper eating extra stamps when clicked with a stack of more than 1
- Set the maximum stack size of ItemBaubleBase to 1